### PR TITLE
add storage module backed by mongodb

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -9,3 +9,7 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-coloredlogs.*]
 ignore_missing_imports = True
+[mypy-motor.*]
+ignore_missing_imports = True
+[mypy-bson.*]
+ignore_missing_imports = True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,18 @@ services:
       main:
         aliases:
           - api
+  db:
+    image: mongo:latest
+    ports:
+      - 27017:27017
+    volumes:
+      - mongodb_data_container:/data/db
+    networks:
+      main:
+        aliases:
+          - db
 
 networks:
   main:
+volumes:
+  mongodb_data_container:

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
     - aiohttp
     - discord.py
     - jsonpickle
+    - motor
     - quart
     - distest==0.6.1
     - mypy==0.812

--- a/pkmntypes.py
+++ b/pkmntypes.py
@@ -2,6 +2,8 @@ import json
 from dataclasses import dataclass
 from typing import Any, Optional
 import logging
+from bson.objectid import ObjectId
+from motor.motor_asyncio import AsyncIOMotorClientSession
 
 
 def _case_insensitive_pop(
@@ -42,6 +44,7 @@ class Pokemon():
 	:param Type: The type of Pokemon
 	"""
 
+	_id: Optional[ObjectId]
 	Name: str
 	NatDex: int
 	Level: int
@@ -62,6 +65,7 @@ class Pokemon():
 	Type: int
 
 	def __init__(self, **kwargs):
+		self._id = kwargs.pop("id", None)
 		if len(kwargs) == 0:
 			return
 		self.Name: str = _case_insensitive_pop(kwargs, 'Name')
@@ -82,6 +86,11 @@ class Pokemon():
 		self.Friendship: int = _case_insensitive_pop(kwargs, 'Friendship')
 		self.OriginalTrainerID: int = _case_insensitive_pop(kwargs, 'OriginalTrainerID')
 		self.Type: int = _case_insensitive_pop(kwargs, 'Type')
+
+	async def save(self, session: AsyncIOMotorClientSession = None):
+		"""Alias for `storage.save_object(pokemon)`."""
+		import storage # avoid circular import
+		await storage.save_object(self, session=session)
 
 
 @dataclass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiohttp
 discord.py
 jsonpickle
+motor
 quart
 coloredlogs

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -28,5 +28,6 @@ if [ -z "$CI_BOT_TOKEN$CI_BOT_TARGET$CI_TEST_CHANNEL" ] && [ ! -f "$CONFIG_FILE"
 fi
 
 grep -v -e pydocstyle -e yapf -e pre-commit requirements-dev.txt | xargs pip install
+python -m unittest discover "tests/integration/api" || exit 1
+python -m unittest discover "tests/integration/storage" || exit 2
 find tests/integration/bot -type f -name "*.py" -print0 | xargs -0 -n 1 -I {} python3 {} "$CI_BOT_TARGET" "$CI_BOT_TOKEN" -c "$CI_TEST_CHANNEL" -r all
-python -m unittest discover "tests/integration/api"

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -28,6 +28,6 @@ if [ -z "$CI_BOT_TOKEN$CI_BOT_TARGET$CI_TEST_CHANNEL" ] && [ ! -f "$CONFIG_FILE"
 fi
 
 grep -v -e pydocstyle -e yapf -e pre-commit requirements-dev.txt | xargs pip install
-python -m unittest discover "tests/integration/api" || exit 1
-python -m unittest discover "tests/integration/storage" || exit 2
+python -m unittest discover "tests/integration/api"
+python -m unittest discover "tests/integration/storage"
 find tests/integration/bot -type f -name "*.py" -print0 | xargs -0 -n 1 -I {} python3 {} "$CI_BOT_TARGET" "$CI_BOT_TOKEN" -c "$CI_TEST_CHANNEL" -r all

--- a/storage.py
+++ b/storage.py
@@ -23,7 +23,7 @@ def pokemon() -> AsyncIOMotorCollection:
 
 
 async def save_object(obj: Union[Pokemon], session: AsyncIOMotorClientSession = None):
-	"""Save the given object to the database. If `_id` is not set, a new entry will be created. If `_id` is set, it will try to update the document with that ID.
+	"""Save the given object to the database. If `_id` is not set, a new entry will be created and the object's `_id` will be updated. If `_id` is set, it will try to update the document with that ID.
 
 	:param session: The database session to use to save the pokemon. If not provided, it will not be used.
 

--- a/storage.py
+++ b/storage.py
@@ -1,0 +1,48 @@
+import asyncio
+from pkmntypes import Pokemon
+from typing import Union
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorClientSession, AsyncIOMotorCollection, AsyncIOMotorDatabase
+import logging
+
+log = logging.getLogger(__name__)
+client: AsyncIOMotorClient = AsyncIOMotorClient('mongodb://db/brock')
+db: AsyncIOMotorDatabase = client.brock
+
+
+def _set_client(new_client: AsyncIOMotorClient):
+	"""Manually set the mongodb client that `storage` should use. Only to be used in tests."""
+
+	global client, db
+	client = new_client
+	db = client.brock_test
+
+
+def pokemon() -> AsyncIOMotorCollection:
+	"""Get the Pokemon collection to be able to interact with the database."""
+	return db.pokemon
+
+
+async def save_object(obj: Union[Pokemon], session: AsyncIOMotorClientSession = None):
+	"""Save the given object to the database. If `_id` is not set, a new entry will be created. If `_id` is set, it will try to update the document with that ID.
+
+	:param session: The database session to use to save the pokemon. If not provided, it will not be used.
+
+	:raises:
+		TypeError: The type of object provided is not allowed to be saved in the database.
+	"""
+	if isinstance(obj, Pokemon):
+		coll = pokemon()
+	else:
+		raise TypeError(f"Invalid type for obj: {type(obj)}")
+	if obj._id != None:
+		result = await coll.update_one(
+			{'_id': obj._id}, {'$set': obj.__dict__}, session=session
+		)
+		log.debug(f"Updated {type(obj)} ({result.modified_count} modified)")
+	else:
+		result = await coll.insert_one(
+			{k: v
+				for k, v in obj.__dict__.items() if k != "_id"}, session=session
+		)
+		obj._id = result.inserted_id
+		log.debug(f"Inserted {type(obj)} ({obj._id})")

--- a/tests/integration/storage/test_storage.py
+++ b/tests/integration/storage/test_storage.py
@@ -1,0 +1,38 @@
+import unittest
+
+from motor.motor_asyncio import AsyncIOMotorClient
+from turns import *
+from pkmntypes import *
+from unittest.mock import patch
+import asyncio
+import storage
+
+
+class TestStorage(unittest.TestCase):
+
+	def setUp(self):
+		self.loop = asyncio.new_event_loop()
+		asyncio.set_event_loop(self.loop)
+		self.client = AsyncIOMotorClient('mongodb://db/brock_test', io_loop=self.loop)
+		storage._set_client(self.client)
+
+	def tearDown(self):
+
+		async def tearDown_async():
+			await self.client.drop_database("brock_test")
+
+		self.loop.run_until_complete(tearDown_async())
+		self.loop.close()
+
+	def test_pokemon_save(self):
+
+		async def go():
+			pkmn = Pokemon()
+			await pkmn.save()
+			self.assertIsNotNone(pkmn._id)
+
+		return self.loop.run_until_complete(go())
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
Adds the `storage` module and provides a utility for saving any object that has an `_id` field to the database.

closes #41﻿
